### PR TITLE
enable jscep to be used with Spring Boot 3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<groupId>com.google.code.jscep</groupId>
 	<artifactId>jscep</artifactId>
 	<packaging>jar</packaging>
-	<version>2.5.7-SNAPSHOT</version>
+	<version>3.0.0</version>
 	<name>jscep</name>
 	<description>Java implementation of the Simple Certificate Enrollment Protocol</description>
 	<url>http://jscep.org/</url>
@@ -13,6 +13,7 @@
 		<sonar.core.codeCoveragePlugin>jacoco</sonar.core.codeCoveragePlugin>
 		<sonar.dynamicAnalysis>reuseReports</sonar.dynamicAnalysis>
 		<sonar.jacoco.reportPaths>${project.basedir}/../target/jacoco.exec,${project.basedir}/../target/jacoco-it.exec</sonar.jacoco.reportPaths>
+		<jetty.server.version>12.0.3</jetty.server.version>
 	</properties>
 	<issueManagement>
 		<system>GitHub </system>
@@ -150,8 +151,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.11.0</version>
 				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
+					<source>17</source>
+					<target>17</target>
 					<compilerArgs>
 						<arg>-Xlint</arg>
 					</compilerArgs>
@@ -265,8 +266,8 @@
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>
-			<artifactId>junit-dep</artifactId>
-			<version>4.10</version>
+			<artifactId>junit</artifactId>
+			<version>4.11</version>
 			<scope>test</scope>
 			<exclusions>
 				<exclusion>
@@ -287,18 +288,34 @@
 				</exclusion>
 			</exclusions>
 		</dependency>
+
 		<dependency>
 			<groupId>org.eclipse.jetty</groupId>
-			<artifactId>test-jetty-servlet</artifactId>
-			<version>8.2.0.v20160908</version>
+			<artifactId>jetty-server</artifactId>
+			<version>${jetty.server.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>javax.servlet</groupId>
-			<artifactId>servlet-api</artifactId>
-			<version>2.5</version>
+			<groupId>org.eclipse.jetty.ee10</groupId>
+			<artifactId>jetty-ee10-webapp</artifactId>
+			<version>${jetty.server.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.eclipse.jetty.ee10</groupId>
+			<artifactId>jetty-ee10-servlet</artifactId>
+			<version>${jetty.server.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>jakarta.servlet</groupId>
+			<artifactId>jakarta.servlet-api</artifactId>
+			<version>6.0.0</version>
 			<scope>provided</scope>
 		</dependency>
+
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>

--- a/src/main/java/org/jscep/server/ScepServlet.java
+++ b/src/main/java/org/jscep/server/ScepServlet.java
@@ -37,11 +37,11 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import org.apache.commons.io.IOUtils;
 import org.bouncycastle.asn1.cms.IssuerAndSerialNumber;
 import org.bouncycastle.asn1.x500.X500Name;
@@ -109,11 +109,19 @@ public abstract class ScepServlet extends HttpServlet {
             op = getOperation(req);
             if (op == null) {
                  // The operation parameter must be set.
+
+                // Providing a custom reason message is deprecated:
+                // https://docs.oracle.com/javaee/7/api/javax/servlet/http/HttpServletResponse.html#setStatus-int-java.lang.String-
+                // @ToDo consider dropping the second parameter if no client relies on it
                 res.sendError(HttpServletResponse.SC_BAD_REQUEST, "Missing \"operation\" parameter.");
                 return;
             }
         } catch (IllegalArgumentException e) {
             // The operation was not recognised.
+
+            // Providing a custom reason message is deprecated:
+            // https://docs.oracle.com/javaee/7/api/javax/servlet/http/HttpServletResponse.html#setStatus-int-java.lang.String-
+            // @ToDo consider dropping the second parameter if no client relies on it
             res.sendError(HttpServletResponse.SC_BAD_REQUEST, "Invalid \"operation\" parameter.");
             return;
         }
@@ -327,6 +335,9 @@ public abstract class ScepServlet extends HttpServlet {
             res.getOutputStream().write(signedData.getEncoded());
             res.getOutputStream().close();
         } else {
+            // Providing a custom reason message is deprecated:
+            // https://docs.oracle.com/javaee/7/api/javax/servlet/http/HttpServletResponse.html#setStatus-int-java.lang.String-
+            // @ToDo consider dropping the second parameter if no client relies on it
             res.sendError(HttpServletResponse.SC_BAD_REQUEST,
                     "Unknown Operation");
         }
@@ -369,6 +380,9 @@ public abstract class ScepServlet extends HttpServlet {
                 .getParameter(MSG_PARAM));
 
         if (certs.isEmpty()) {
+            // Providing a custom reason message is deprecated:
+            // https://docs.oracle.com/javaee/7/api/javax/servlet/http/HttpServletResponse.html#setStatus-int-java.lang.String-
+            // @ToDo consider dropping the second parameter if no client relies on it
             res.sendError(HttpServletResponse.SC_NOT_IMPLEMENTED,
                     "GetNextCACert Not Supported");
         } else {
@@ -410,6 +424,9 @@ public abstract class ScepServlet extends HttpServlet {
                 .getParameter(MSG_PARAM));
         final byte[] bytes;
         if (certs.isEmpty()) {
+            // Providing a custom reason message is deprecated:
+            // https://docs.oracle.com/javaee/7/api/javax/servlet/http/HttpServletResponse.html#setStatus-int-java.lang.String-
+            // @ToDo consider dropping the second parameter if no client relies on it
             res.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
                     "GetCaCert failed to obtain CA from store");
             bytes = new byte[0];

--- a/src/test/java/org/jscep/client/AbstractClientTest.java
+++ b/src/test/java/org/jscep/client/AbstractClientTest.java
@@ -1,25 +1,19 @@
 package org.jscep.client;
 
-import java.security.KeyPair;
-import java.security.KeyPairGenerator;
-import java.security.Security;
-import java.security.cert.CertificateException;
-import java.security.cert.X509Certificate;
-
-import javax.net.ssl.HostnameVerifier;
-import javax.net.ssl.HttpsURLConnection;
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLSession;
-import javax.net.ssl.TrustManager;
-import javax.net.ssl.X509TrustManager;
-import javax.security.auth.callback.CallbackHandler;
-import javax.security.auth.x500.X500Principal;
-
 import org.jscep.client.verification.OptimisticCertificateVerifier;
 import org.jscep.util.X509Certificates;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
+
+import javax.net.ssl.*;
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.x500.X500Principal;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.Security;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
 
 @Ignore
 public abstract class AbstractClientTest extends ScepServerSupport {

--- a/src/test/java/org/jscep/client/ScepServerSupport.java
+++ b/src/test/java/org/jscep/client/ScepServerSupport.java
@@ -1,21 +1,31 @@
 package org.jscep.client;
 
-import java.net.URL;
-
+import org.eclipse.jetty.ee10.servlet.ServletContextHandler;
+import org.eclipse.jetty.server.Connector;
+import org.eclipse.jetty.server.NetworkConnector;
 import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.servlet.ServletHandler;
+import org.eclipse.jetty.server.ServerConnector;
 import org.jscep.server.ScepServletImpl;
 
-public abstract class ScepServerSupport {
-    public URL getUrl() throws Exception {
-        final String path = "/scep/pkiclient.exe";
-        final ServletHandler handler = new ServletHandler();
-        handler.addServletWithMapping(ScepServletImpl.class, path);
-        final Server server = new Server(0);
-        server.setHandler(handler);
-        server.start();
+import java.net.URL;
 
-        final int port = server.getConnectors()[0].getLocalPort();
-        return new URL("http", "localhost", port, path);
+public abstract class ScepServerSupport {
+
+    static final String PATH = "/scep/pkiclient.exe";
+
+    public URL getUrl() throws Exception {
+        final Server server = new Server(0);
+        NetworkConnector connector = new ServerConnector(server);
+        server.addConnector(connector);
+
+        ServletContextHandler context = new ServletContextHandler();
+        context.setContextPath("/");
+        server.setHandler(context);
+        context.addServlet(ScepServletImpl.class, PATH);
+
+        server.start();
+        final int port = connector.getLocalPort();
+
+        return new URL("http", "localhost", port, PATH);
     }
 }

--- a/src/test/java/org/jscep/message/PkiMessageEncoderTest.java
+++ b/src/test/java/org/jscep/message/PkiMessageEncoderTest.java
@@ -1,5 +1,6 @@
 package org.jscep.message;
 
+import static junit.framework.Assert.*;
 import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
@@ -168,7 +169,7 @@ public class PkiMessageEncoderTest {
         CMSSignedData encodedMessage2 = modifySignature(encodedMessage);
         try{
             decoder.decode(encodedMessage2);
-            Assert.fail("decoding exception expected");
+            fail("decoding exception expected");
         }catch(MessageDecodingException e)
         {
             assertEquals("decoding exception", "pkiMessage verification failed.", e.getMessage());

--- a/src/test/java/org/jscep/server/ScepServletImpl.java
+++ b/src/test/java/org/jscep/server/ScepServletImpl.java
@@ -21,8 +21,8 @@ import java.util.Map;
 import java.util.Random;
 import java.util.Set;
 
-import javax.servlet.ServletContext;
-import javax.servlet.ServletException;
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.ServletException;
 
 import org.bouncycastle.asn1.cms.IssuerAndSerialNumber;
 import org.bouncycastle.asn1.x500.X500Name;

--- a/src/test/java/org/jscep/transport/AbstractTransportTest.java
+++ b/src/test/java/org/jscep/transport/AbstractTransportTest.java
@@ -14,6 +14,7 @@ import junit.framework.Assert;
 
 import org.bouncycastle.asn1.cms.IssuerAndSerialNumber;
 import org.bouncycastle.asn1.x500.X500Name;
+import org.eclipse.jetty.server.NetworkConnector;
 import org.eclipse.jetty.server.Server;
 import org.jscep.message.GetCert;
 import org.jscep.message.PkcsPkiEnvelopeEncoder;
@@ -35,10 +36,12 @@ abstract public class AbstractTransportTest {
 
     @Before
     public void setUp() throws Exception {
+
         server = new Server(0);
         server.start();
-        url = new URL("http://localhost:"
-                + server.getConnectors()[0].getLocalPort() + "/");
+        url = new URL("http://localhost:" +
+            ((NetworkConnector)(server.getConnectors()[0])).getLocalPort() + "/");
+
         proxy = Proxy.NO_PROXY;
         transport = getTransport(url);
     }


### PR DESCRIPTION
moved javax to jakarta packages
upgraded to servlet version 6
update to jetty version 12

This PR solves [Issue 292](https://github.com/jscep/jscep/issues/292)
